### PR TITLE
Correção de erro no Cadastro de Itens Patrimoniais

### DIFF
--- a/src/Utils/validate.js
+++ b/src/Utils/validate.js
@@ -4,7 +4,7 @@ const validateName = (name) => {
 };
 
 const validateDescription = (description) => {
-  const regex = /^[a-zA-Z ]{2,50}$/;
+  const regex = /^[a-zA-Z0-9 ]{2,50}$/;
   return (regex.test(description) && description !== undefined);
 };
 

--- a/src/Utils/validate.js
+++ b/src/Utils/validate.js
@@ -13,7 +13,8 @@ const validate = (name, description) => {
 
   if (!validateName(name)) {
     err.push('invalid name');
-  } if (!validateDescription(description)) {
+  } 
+  if (!validateDescription(description)) {
     err.push('invalid description');
   }
   return err;


### PR DESCRIPTION
Co-authored-by: Ana Júlia <aluzianobriceno@gmail.com>

## Objetivos

No campo de descrição de "Criar um patrimonio", deve ser possível colocar números e letras

Capturas de tela
![image](https://github.com/DITGO/2021-2-SiGeD-Patrimonio/assets/54222696/3e9b0399-255b-43f0-bba4-dd840ec9199d)


## Issues resolvidas com o PR
Repositório DITGO:
resolves https://github.com/DITGO/2021-2-SiGeD-Doc/issues/52

Respositório GCES-2023/2:
resolves https://github.com/Siged-Gces-2023-2/2023.2-SIGeD-GCES-Doc/issues/13